### PR TITLE
Fail earlier on memory allocation failures

### DIFF
--- a/tinygrad/runtime/lib.py
+++ b/tinygrad/runtime/lib.py
@@ -80,7 +80,7 @@ class LRUAllocator:
     while len(self.aging_order[device]) and self._get_cur_free_space(device) < space_to_free: # When OOM removing lru buffers.
       bucket, epoch = self.aging_order[device].popleft()
       if self.cached_buffers[bucket] and self.cached_buffers[bucket][-1][1] == epoch: self._free_buffer(self.cached_buffers[bucket].pop()[0]) # Free cached buffer if it is still in cache.
-    assert self._get_cur_free_space(device) > space_to_free, f"out of memory. requested {space_to_free/1e9:5.2f} GB, available {self._get_cur_free_space(device)/1e9:5.2f} GB"
+    assert self._get_cur_free_space(device) > space_to_free, f"out of memory - requested: {space_to_free/1e9:5.2f} GB, available: {self._get_cur_free_space(device)/1e9:5.2f} GB"
 
   def _alloc_buffer(self, size, dtype, device, **kwargs):
     self.ensure_has_free_space(size*dtype.itemsize, device)

--- a/tinygrad/runtime/lib.py
+++ b/tinygrad/runtime/lib.py
@@ -80,6 +80,7 @@ class LRUAllocator:
     while len(self.aging_order[device]) and self._get_cur_free_space(device) < space_to_free: # When OOM removing lru buffers.
       bucket, epoch = self.aging_order[device].popleft()
       if self.cached_buffers[bucket] and self.cached_buffers[bucket][-1][1] == epoch: self._free_buffer(self.cached_buffers[bucket].pop()[0]) # Free cached buffer if it is still in cache.
+    assert self._get_cur_free_space(device) > space_to_free, f"out of memory. requested {space_to_free/1e9:5.2f} GB, available {self._get_cur_free_space(device)/1e9:5.2f} GB"
 
   def _alloc_buffer(self, size, dtype, device, **kwargs):
     self.ensure_has_free_space(size*dtype.itemsize, device)

--- a/tinygrad/runtime/ops_metal.py
+++ b/tinygrad/runtime/ops_metal.py
@@ -11,9 +11,8 @@ from tinygrad.shape.symbolic import Variable, Node
 
 class MetalAllocator(LRUAllocator):
   def _do_alloc(self, size, dtype, device, **kwargs):
-    if (buf_len := size*dtype.itemsize) > (max_len := METAL.device.maxBufferLength()): raise RuntimeError(f"tried to create a {buf_len/1e9:5.2f} GB Metal buffer, but the max buffer length is {max_len/1e9:5.2f} GB")
-    if (buf := METAL.device.newBufferWithLength_options_(buf_len, Metal.MTLResourceStorageModeShared)): return buf
-    else: raise RuntimeError(f"failed to create a {buf_len/1e9:5.2f} GB Metal buffer")
+    assert (buf_len := size*dtype.itemsize) < (max_len := METAL.device.maxBufferLength()) and (buf := METAL.device.newBufferWithLength_options_(buf_len, Metal.MTLResourceStorageModeShared)), f"Failed to create a {buf_len/1e9:5.2f} GB Metal buffer. {f'The max buffer length is {max_len/1e9:5.2f} GB.' if buf_len > max_len else 'Metal returned None {buf}.'}"
+    return buf
   def _do_free(self, buf): buf.release()
   def _cached_bufkey(self, size, dtype, device): return (device, size*dtype.itemsize) # Buffers of the same length could be reused, no matter what dtype.
 

--- a/tinygrad/runtime/ops_metal.py
+++ b/tinygrad/runtime/ops_metal.py
@@ -10,7 +10,9 @@ from tinygrad.runtime.lib import RawBufferMapped, RawBuffer, LRUAllocator
 from tinygrad.shape.symbolic import Variable, Node
 
 class MetalAllocator(LRUAllocator):
-  def _do_alloc(self, size, dtype, device, **kwargs): return METAL.device.newBufferWithLength_options_(size*dtype.itemsize, Metal.MTLResourceStorageModeShared)
+  def _do_alloc(self, size, dtype, device, **kwargs):
+    if (buf := METAL.device.newBufferWithLength_options_(size*dtype.itemsize, Metal.MTLResourceStorageModeShared)): return buf
+    else: raise RuntimeError(f"failed to create a {size*dtype.itemsize/1e9:5.2f} GB METAL buffer")
   def _do_free(self, buf): buf.release()
   def _cached_bufkey(self, size, dtype, device): return (device, size*dtype.itemsize) # Buffers of the same length could be reused, no matter what dtype.
 

--- a/tinygrad/runtime/ops_metal.py
+++ b/tinygrad/runtime/ops_metal.py
@@ -11,8 +11,9 @@ from tinygrad.shape.symbolic import Variable, Node
 
 class MetalAllocator(LRUAllocator):
   def _do_alloc(self, size, dtype, device, **kwargs):
-    if (buf := METAL.device.newBufferWithLength_options_(size*dtype.itemsize, Metal.MTLResourceStorageModeShared)): return buf
-    else: raise RuntimeError(f"failed to create a {size*dtype.itemsize/1e9:5.2f} GB METAL buffer")
+    if (buf_len := size*dtype.itemsize) > (max_len := METAL.device.maxBufferLength()): raise RuntimeError(f"tried to create a {buf_len/1e9:5.2f} GB Metal buffer, but the max buffer length is {max_len/1e9:5.2f} GB")
+    if (buf := METAL.device.newBufferWithLength_options_(buf_len, Metal.MTLResourceStorageModeShared)): return buf
+    else: raise RuntimeError(f"failed to create a {buf_len/1e9:5.2f} GB Metal buffer")
   def _do_free(self, buf): buf.release()
   def _cached_bufkey(self, size, dtype, device): return (device, size*dtype.itemsize) # Buffers of the same length could be reused, no matter what dtype.
 


### PR DESCRIPTION
If we pop all aging buffers, ensure_has_free_space() might return with space_to_free still unavailable. Hence the next change.

[Metal buffers](https://developer.apple.com/documentation/metal/mtldevice/1433375-newbufferwithlength) have a max length and return null on allocation failure.